### PR TITLE
Fixes alignment of user profile icon

### DIFF
--- a/src/features/menu/menu.tsx
+++ b/src/features/menu/menu.tsx
@@ -59,7 +59,7 @@ export const MainMenu = () => {
           <></>
         )}
       </div>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 items-center">
         <ThemeToggle />
         <UserProfile />
       </div>


### PR DESCRIPTION
It's sibling div has `items-center` applied, but this div was missing it and it meant that the user profile icon was not horizontally aligned with the other icons.

Before:
![image](https://github.com/microsoft/azurechat/assets/8124536/9784ddb7-694c-490c-ba5e-3db6cd651dc6)

After:
![image](https://github.com/microsoft/azurechat/assets/8124536/6661fa2c-d9d2-4356-aa67-3b2e756635d4)
