### PR TITLE
TTL Chat History Retention Fix

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -309,7 +309,6 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
         ]
         kind: 'Hash'
       }
-      defaultTtl: 86400
     }
   }
 }


### PR DESCRIPTION
Removing container level ttl setting. It was originally set to 1 day, which deleted chat history after 24 hours.