### PR TITLE
added Australia east into list of Open AI deployment regions

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -11,7 +11,7 @@ param location string
 
 // azure open ai 
 @description('Location for the OpenAI resource group')
-@allowed(['canadaeast', 'eastus', 'francecentral', 'japaneast', 'northcentralus'])
+@allowed(['canadaeast', 'eastus', 'francecentral', 'japaneast', 'northcentralus', 'australieast'])
 @metadata({
   azd: {
     type: 'location'


### PR DESCRIPTION
Now text-embedding-ada-002 is also available in Australia East region. https://learn.microsoft.com/en-au/azure/ai-services/openai/concepts/models?WT.mc_id=AZ-MVP-5004796#embeddings-models-1