### PR TITLE
Refactor file loading in change-log page

### DIFF
--- a/src/app/change-log/page.tsx
+++ b/src/app/change-log/page.tsx
@@ -7,12 +7,7 @@ import { Suspense } from "react";
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  // read local file from src/app/update/page.tsx
-  const file = await fs.readFile(
-    process.cwd() + "/app/change-log/update.md",
-    "utf8"
-  );
-
+  const content = await loadContent();
   return (
     <Card className="h-full flex justify-center flex-1 overflow-y-scroll">
       <div className="flex flex-col gap-8 py-8">
@@ -20,9 +15,26 @@ export default async function Home() {
           <VersionDisplay />
         </Suspense>
         <div className="prose prose-slate dark:prose-invert break-words prose-p:leading-relaxed prose-pre:p-0 max-w-4xl ">
-          <Markdown content={file} />
+          <Markdown content={content} />
         </div>
       </div>
     </Card>
   );
 }
+
+const loadContent = async () => {
+  if (process.env.NODE_ENV === "production") {
+    const response = await fetch(
+      "https://raw.githubusercontent.com/microsoft/azurechat/main/src/app/change-log/update.md",
+      {
+        cache: "no-cache",
+      }
+    );
+    return await response.text();
+  } else {
+    return await fs.readFile(
+      process.cwd() + "/app/change-log/update.md",
+      "utf8"
+    );
+  }
+};


### PR DESCRIPTION
This pull request to the `src/app/change-log/page.tsx` file improves the `Home` function by loading the content of the `update.md` file from a remote server in production mode and from the local file system in development mode. It also adds a new `loadContent` function to handle the loading of the file content, removes the `fs` module, and updates the `Markdown` component to use the `content` variable instead of the `file` variable.

Main interface changes:

* <a href="diffhunk://#diff-8dcbcb36750f4a2b6a41b647b0a834846e7f0900503cb261a105dc5d9d2dda07L10-R40">`src/app/change-log/page.tsx`</a>: The `Home` function now loads the content of the `update.md` file from a remote server in production mode and from the local file system in development mode.