### PR TITLE
Updated dockerfile with options for including your own root certificate and deploying your container to an Azure App Service.

### DIFF
--- a/src/dockerfile
+++ b/src/dockerfile
@@ -1,5 +1,11 @@
 FROM node:18-alpine AS base
 
+# If using a proxy / secure web gateway / etc., you may need to add your own PKI's root certificate in order for your containers to reach out to web resources.
+# Customize the {your_certificate_file} strings and uncomment the following three lines to allow for this scenario.
+# COPY {your_certificate_file}.pem /usr/local/share/ca-certificates/
+# RUN cat /usr/local/share/ca-certificates/{your_certificate_file}.pem >>/etc/ssl/certs/ca-certificates.crt
+# ARG NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
@@ -53,6 +59,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs
 
 ENV PORT 3000
+# If deploying your container to an Azure App Service, you may need to switch this variable value to 0.0.0.0 in order for HTTP responses to be returned from the container. Uncomment / comment out the following two lines as needed.
+# ENV HOSTNAME 0.0.0.0
 ENV HOSTNAME localhost
 
 # set environment variables here to run locally


### PR DESCRIPTION
While deploying this privately, I encountered a few issues which caused some significant trouble. Two of these are addressed by updating the dockerfile, and I hope this PR can save others some time and headaches.

My modifications are commented out by default and are opt-in configuration decisions.

### Using a Proxy / SWG / etc. which intercepts SSL

This scenario requires uploading your own root certificate to the container and configuring Node to trust it. This modification was based on [this Stack Overflow conversation](https://stackoverflow.com/questions/75898561/npm-unable-to-get-issuer-cert-locally-in-docker-behind-corporate-firewall).

### Custom Container + Azure App Service

Our solution used the above custom container deployed to an Azure App Service via an Azure Container Registry. The container would continually get shut down due to failing to respond to HTTP ping requests. Based on [this somewhat related tutorial](https://learn.microsoft.com/en-us/azure/app-service/tutorial-custom-container), I tried switching the HOSTNAME environment variable value to **0.0.0.0**. This instantly solved the problem.