### PR TITLE
Specify a "Content-Type" header in response streams so that Cloudflar…

### DIFF
--- a/src/features/chat/chat-services/chat-api-data.ts
+++ b/src/features/chat/chat-services/chat-api-data.ts
@@ -95,7 +95,9 @@ export const ChatAPIData = async (props: PromptGPTProps) => {
       },
     });
 
-    return new StreamingTextResponse(stream);
+    return new StreamingTextResponse(stream, {
+      headers: {"Content-Type": "text/event-stream"},
+    });
   } catch (e: unknown) {
     if (e instanceof Error) {
       return new Response(e.message, {

--- a/src/features/chat/chat-services/chat-api-simple.ts
+++ b/src/features/chat/chat-services/chat-api-simple.ts
@@ -49,7 +49,9 @@ export const ChatAPISimple = async (props: PromptGPTProps) => {
         });
       },
     });
-    return new StreamingTextResponse(stream);
+    return new StreamingTextResponse(stream, {
+      headers: {"Content-Type": "text/event-stream"},
+    });
   } catch (e: unknown) {
     if (e instanceof Error) {
       return new Response(e.message, {


### PR DESCRIPTION
By default, the upstream "ai" module (https://github.com/vercel/ai/) is returning the response from the Azure OpenAI API with a "text/plain" Content-Type.  If your azurechat instance is hosted behind a cloudflared tunnel (maybe just Cloudflare in general, I haven't tested this), the response will be buffered by cloudflare(d) and returned all at once.

Other than not being the expected experience, this can lead to timeouts (cloudflare default = 100s) if the response is long or slow to generate.  If the response is streamed, there should be enough data flowing to avoid this timeout.

Cloudflared looks for the Content-Type response header and if it is "text/event-stream" it will know not to buffer the response but to send it immediately to the requestor. [Reference](https://github.com/cloudflare/cloudflared/issues/1095).