### PR TITLE
Corrected broken links to non-existent pages in doco

### DIFF
--- a/docs/1-introduction.md
+++ b/docs/1-introduction.md
@@ -67,4 +67,4 @@ To reduce costs, you can switch to free SKUs for Azure App Service, Azure Cognit
 > **Warning**
 > To avoid unnecessary costs, remember to destroy your provisioned resources by deleting the resource group.
 
-[Next](/docs/2-provision-azure-resources.md)
+[Next](/docs/3-run-locally.md)

--- a/docs/3-run-locally.md
+++ b/docs/3-run-locally.md
@@ -4,7 +4,7 @@ Clone this repository locally or fork to your Github account. Run all of the the
 
 ## Prerequisites
 
-- **History Database**: If you didn't [provision the Azure resources](2-provision-azure-resources.md), you **must** at least deploy an instance of Cosmos DB in your Azure Subscription to store chat history.
+- **History Database**: If you didn't [provision the Azure resources](/README.md#deploy-to-azure) by following one of the deployment options you **must** at least deploy an instance of Cosmos DB in your Azure Subscription to store chat history.
 
 - **Identity Provider**: For local development, you have the option of using a username / password. If you prefer to use an Identity Provider, follow the [instructions](3-run-locally.md) to add one.
 

--- a/docs/3-run-locally.md
+++ b/docs/3-run-locally.md
@@ -6,7 +6,7 @@ Clone this repository locally or fork to your Github account. Run all of the the
 
 - **History Database**: If you didn't [provision the Azure resources](/README.md#deploy-to-azure) by following one of the deployment options you **must** at least deploy an instance of Cosmos DB in your Azure Subscription to store chat history.
 
-- **Identity Provider**: For local development, you have the option of using a username / password. If you prefer to use an Identity Provider, follow the [instructions](3-run-locally.md) to add one.
+- **Identity Provider**: For local development, you have the option of using a username / password. If you prefer to use an Identity Provider, follow the [instructions](5-add-identity.md) to add one.
 
 ## Steps
 


### PR DESCRIPTION
**doco updates only**
There were two references to a missing page: `docs/2-provision-azure-resources.md`.

Presumably, the content of this page is now covered by the `/README.md#deploy-to-azure` section. I corrected the **Next** link on the _Intro_ page to go straight to the _Run locally_ page. On the _Run locally_ page, I've pointed the link in Prerequisites back to the  `/README.md#deploy-to-azure` section.

Also, on _Run locally_ , I corrected a recursive link to correctly point to the `docs/5-add-identity.md` page.