### PR TITLE
Update .gitignore to Exclude '.env' File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+.env
+*.local
 
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION
Hello,

I've updated the `.gitignore` file to better handle environment variable files. Previously, the pattern `.env*` might unintentionally exclude `.env` files. Now, it's split into two lines: `.env` and `*.local`, ensuring both global and local environment files are correctly ignored.

Change: https://github.com/microsoft/azurechat/commit/31ef94975bc9c192a99e3da4a82ce7d3db318e33

This adjustment prevents sensitive data from being accidentally committed, enhancing the repository's security.

Thanks for considering this update. Looking forward to your feedback.