### PR TITLE
Use newer devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Azure Chat Solution Accelerator powered by Azure Open AI Service",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bookworm",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {


### PR DESCRIPTION
Next.js 14 [requires](https://nextjs.org/docs/app/building-your-application/upgrading/version-14#v14-summary) Node.js 18.17.0 or later, [released on 2023-07-18](https://nodejs.org/dist/v18.17.0/).
However, the image `mcr.microsoft.com/devcontainers/javascript-node:0-18-bullseye` specified in devcontainer.json [has not been updated since 2023-06-08](https://mcr.microsoft.com/en-us/product/devcontainers/javascript-node/tags). This image currently contains Node.js 18.16.0, so you cannot run azurechat locally in devcontainer.