### PR TITLE
Fix sign-in loop when email is not set in Azure AD account

### DIFF
--- a/src/features/auth-page/auth-api.ts
+++ b/src/features/auth-page/auth-api.ts
@@ -39,13 +39,15 @@ const configureIdentityProvider = () => {
         clientSecret: process.env.AZURE_AD_CLIENT_SECRET!,
         tenantId: process.env.AZURE_AD_TENANT_ID!,
         async profile(profile) {
+          const email = profile.email || profile.preferred_username || "";
           const newProfile = {
             ...profile,
+            email,
             // throws error without this - unsure of the root cause (https://stackoverflow.com/questions/76244244/profile-id-is-missing-in-google-oauth-profile-response-nextauth)
             id: profile.sub,
             isAdmin:
-              adminEmails?.includes(profile.email.toLowerCase()) ||
-              adminEmails?.includes(profile.preferred_username.toLowerCase()),
+              adminEmails?.includes(profile.email?.toLowerCase()) ||
+              adminEmails?.includes(profile.preferred_username?.toLowerCase()),
           };
           return newProfile;
         },


### PR DESCRIPTION
Fix #273, May related: #408, #418

The profile object returned when signing in from Azure AD may be missing the `email` property.
In this case, the following will occur.
1. The following code will fail on `profile.email.toLowerCase()`, so AzureADProvider doesn't return profile and cause an sign-in loop.
   - <https://github.com/microsoft/azurechat/blob/f53e5259ff830ab0de015b3c1eaa6e458f967067/src/features/auth-page/auth-api.ts#L47>
2. The `email` property is used in the `userHashedId` function to identify users in the database, but if the `email` property is `undefined`, the hashing fails.
   - <https://github.com/microsoft/azurechat/blob/f53e5259ff830ab0de015b3c1eaa6e458f967067/src/features/auth-page/helpers.ts#L28-L32>

In this PR, if the `email` property is missing, the `preferred_username` property, which contains the user principal name, is used as the `email` instead.

(Note: Personally, I believe using an immutable identifier like `sub` for `userHashedId` would be more robust than using `email` or `preferred_username` (which [Microsoft's documentation](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#payload-claims) states are mutable). However, implementing this idea is not included in this PR to maintain compatibility with previously stored data.)